### PR TITLE
chapter2のためのtsの環境構築(ベリー本参照)

### DIFF
--- a/chapter2_ts_basis/package-lock.json
+++ b/chapter2_ts_basis/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "chapter2_ts_basis",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "chapter2_ts_basis",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@types/node": "^14.14.10",
+        "typescript": "^4.6.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "14.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
+      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  }
+}

--- a/chapter2_ts_basis/package.json
+++ b/chapter2_ts_basis/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "chapter2_ts_basis",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/node": "^14.14.10",
+    "typescript": "^4.6.2"
+  }
+}


### PR DESCRIPTION
- `npm init`で、`package.json`を生成。
  - `package.json`は、プロジェクトの依存関係を記録するもの。依存関係を記録するため、node.js上で実行されるプログラムだけでなく、ビルドにnode.jsを使う場合にも用いられる。
- `npm install --save-dev typescript @types/node`で、typescriptと@types/nodeというパッケージをdevDependenciesであることを表して、プロジェクトにインストールする。
  - `node_modules`ディレクトリと、`package-lock.json`が生成される。
  - `node_modules`ディレクトリに上記2つのパッケージがインストールされるため、node_modulesディレクトリは.gitignoreで無視する必要がある。
  - `package-lock.json`は、インストールされているパッケージの情報を記述しているファイル。npmが自動的にメンテナンスする。コミットするのが良いとされている。